### PR TITLE
SRE-2474: Fix tpl render template

### DIFF
--- a/charts/shared/common-gitops/Chart.yaml
+++ b/charts/shared/common-gitops/Chart.yaml
@@ -25,4 +25,4 @@ name: common-gitops
 sources:
   - https://github.com/luminartech/helm-charts-public/charts/common-gitops
 type: library
-version: "1.0.3-1"
+version: "1.0.4"

--- a/charts/shared/common-gitops/templates/_tplvalues.tpl
+++ b/charts/shared/common-gitops/templates/_tplvalues.tpl
@@ -10,8 +10,11 @@ Usage:
 */}}
 {{- define "common-gitops.tplvalues.render" -}}
     {{- if typeIs "string" .value -}}
-        {{- tpl .value .context }}
+        {{- tpl .value .context -}}
     {{- else -}}
-        {{- tpl (.value | toYaml) .context }}
+        {{- /* Avoid returning {} or [] */ -}}
+        {{- with .value -}}
+            {{- tpl (. | toYaml) $.context -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Tplrender template still returns `{}` even thought it's an empty value. Return "" - it will be valid in all cases.