### PR TITLE
Increase chart version before any release

### DIFF
--- a/.github/workflows/helm-package-release.yaml
+++ b/.github/workflows/helm-package-release.yaml
@@ -11,14 +11,18 @@ on:
     branches:
       - main
     paths:
-      # Create a release on version update
-      - 'charts/**/Chart.yaml'
+      - 'charts/**/**.yaml'
+      - 'charts/**/**.tpl'
 permissions:
   contents: write
 jobs:
   package-and-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Generate token
         id: generate_token
         uses: tibdex/github-app-token@v1
@@ -26,7 +30,7 @@ jobs:
           app_id: ${{ secrets.SOFTWARE_APP_ID }}
           private_key: ${{ secrets.SOFTWARE_APP_PRIVATE_KEY }}
           installation_id: ${{ secrets.SOFTWARE_APP_INSTALLATION_ID }}
-      - name: Checkout repo
+      - name: Current Repository Checkout
         uses: actions/checkout@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
@@ -61,6 +65,7 @@ jobs:
           cd luminartech/helm-charts-public
           git config user.name "CI Bot"
           git config user.email "sre@luminartech.com"
+          pip3 install -r scripts/requirements.txt
           chart_paths=(${{ inputs.chart-path }})
           mv_cmd_flags=""
           if [ ${#chart_paths[@]} -gt 0 ]; then
@@ -78,6 +83,11 @@ jobs:
           for chart in "${charts_dirs_changed[@]}"; do
             cd ${chart}
             if [ -f Chart.yaml ]; then
+              echo "Incrementing the version"
+              ./${{workspace_dir}}/luminartech/helm-charts-public/scripts/incver.py Chart.yaml
+              git add Chart.yaml
+              git commit -m "Release of ${chart}"
+              git push origin
               echo "Generating helm package for ${chart}"
               helm dependency update
               rm -f *.tgz || true

--- a/scripts/incver.py
+++ b/scripts/incver.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Increments the prerelease version by one in "version" field of a yaml file
+# Input: one positional argument - path to yaml file with "version" key in it (Chart.yaml)
+
+import sys
+import os
+import semver
+from ruamel.yaml import YAML
+
+filename = sys.argv[1]
+yaml = YAML()
+with open(filename, "r") as f:
+    data = yaml.load(f)
+version = semver.parse_version_info(data["version"])
+if version.prerelease:
+    version = version.replace(prerelease=int(version.prerelease)+1)
+else:
+    version = version.replace(prerelease=0)
+data["version"] = str(version)
+yaml.indent(mapping=2, sequence=4, offset=2)
+with open(f"{filename}.bak", "w") as f:
+    yaml.dump(data, f)
+os.rename(f"{filename}.bak", filename)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+semver==2.13.0
+ruamel.yaml==0.17.21


### PR DESCRIPTION
Rationale: current process requires careful checking whether chart got actually released or not and creation of additional PR to trigger a new release since errors are sometimes not recoverable. It takes time and efforts, especially when change happens in common-gitops chart.