### PR TITLE
Add helm chart-releaser github action

### DIFF
--- a/.github/workflows/helm-chart-releaser.yaml
+++ b/.github/workflows/helm-chart-releaser.yaml
@@ -1,0 +1,32 @@
+name: "[HELM] Helm Chart Releaser"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Rationale:
- No need to invest time in maintaining own releasing solution
- Support from community built around existing project
- Simpler setup: one repository instead of two
- Change should not affect references to the old repository since it can be left intact