### PR TITLE
External-secrets: Use release name for service account

### DIFF
--- a/charts/modules/apps/external-secrets/Chart.yaml
+++ b/charts/modules/apps/external-secrets/Chart.yaml
@@ -7,7 +7,7 @@ description: A Helm chart for external-secrets
 name: external-secrets
 # Below version must match the app version for the consistency.
 # Update minor bit if new tag is needed. e.g. 0.7.0-1
-version: "0.7.1-8"
+version: "0.7.1-9"
 home: https://helm-repo-public.luminarinfra.com
 sources:
   - https://github.com/luminartech/helm-charts-public/

--- a/charts/modules/apps/external-secrets/values.yaml
+++ b/charts/modules/apps/external-secrets/values.yaml
@@ -188,7 +188,7 @@ crossplane-aws-iam:
                   },
                   "Condition": {
                     "StringEquals": {
-                      "oidc.eks.{{ .Values.global.awsRegion }}.amazonaws.com/id/{{ .Values.global.eksHash }}:sub": "system:serviceaccount:{{ .Release.Namespace }}:{{ include "common-gitops.names.release" . }}",
+                      "oidc.eks.{{ .Values.global.awsRegion }}.amazonaws.com/id/{{ .Values.global.eksHash }}:sub": "system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}",
                       "oidc.eks.{{ .Values.global.awsRegion }}.amazonaws.com/id/{{ .Values.global.eksHash }}:aud": "sts.amazonaws.com"
                     }
                   }


### PR DESCRIPTION
Using release name for the service account. This fixes the bug with the SA name in the IAM role policy when fullNameOverride is used.