### PR TITLE
Define IAM policies using Yaml, not Json/String

### DIFF
--- a/charts/iac/crossplane-aws-iam/Chart.yaml
+++ b/charts/iac/crossplane-aws-iam/Chart.yaml
@@ -23,5 +23,5 @@ maintainers:
     email: hennadii.mykhailiuta@luminartech.com
 dependencies:
   - name: common-gitops
-    version: "1.0.4"
+    version: "1.0.5"
     repository: https://helm-repo-public.luminarinfra.com/

--- a/charts/iac/crossplane-aws-iam/Chart.yaml
+++ b/charts/iac/crossplane-aws-iam/Chart.yaml
@@ -10,7 +10,7 @@ description: A Helm chart for crossplane AWS IAM resources
 name: crossplane-aws-iam
 # Below version must match the app version for the consistency.
 # Update minor bit if new tag is needed. e.g. 0.29.0-1
-version: "0.31.0-5"
+version: "0.31.0-6"
 home: https://helm-repo-public.luminarinfra.com
 sources:
   - https://github.com/luminartech/helm-charts-public/charts/crossplane-aws-iam

--- a/charts/iac/crossplane-aws-iam/templates/policy.yaml
+++ b/charts/iac/crossplane-aws-iam/templates/policy.yaml
@@ -14,10 +14,8 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" (.forProvider).name) }}
-    {{ with (.forProvider).document -}}
     document: |
-      {{- include "common-gitops.crossplane.awsPolicy" (dict "value" . "root" $root) | nindent 6 }}
-    {{- end }}
+      {{- include "common-gitops.crossplane.awsPolicy" (dict "value" .forProvider.document "root" $root) | nindent 6 }}
     {{- include "common-gitops.tplvalues.render" (dict
       "value" (omit (.forProvider) "name" "tags" "document")
       "context" $root) | nindent 4 }}

--- a/charts/iac/crossplane-aws-iam/templates/policy.yaml
+++ b/charts/iac/crossplane-aws-iam/templates/policy.yaml
@@ -14,8 +14,24 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" (.forProvider).name) }}
+    {{ with (.forProvider).document -}}
+    document: |
+      {
+        "Version": "{{ .Version | default "2012-10-17" }}",
+        "Statement": [
+        {{- $Sids := keys .Statement | sortAlpha -}}
+        {{ $Statement := .Statement -}}
+        {{ range $sid := $Sids -}}
+          {{ $data := get $Statement $sid -}}
+          {{ $_ := set $data "Sid" $sid -}}
+          {{ $data | mustToPrettyJson | nindent 10 -}}
+          {{ if ne (last $Sids) $sid }},{{ end -}}
+        {{ end }}
+        ]
+      }
+    {{- end }}
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "name" "tags")
+      "value" (omit (.forProvider) "name" "tags" "document")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.tags.list" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}

--- a/charts/iac/crossplane-aws-iam/templates/policy.yaml
+++ b/charts/iac/crossplane-aws-iam/templates/policy.yaml
@@ -16,19 +16,7 @@ spec:
     name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" (.forProvider).name) }}
     {{ with (.forProvider).document -}}
     document: |
-      {
-        "Version": "{{ .Version | default "2012-10-17" }}",
-        "Statement": [
-        {{- $Sids := keys .Statement | sortAlpha -}}
-        {{ $Statement := .Statement -}}
-        {{ range $sid := $Sids -}}
-          {{ $data := get $Statement $sid -}}
-          {{ $_ := set $data "Sid" $sid -}}
-          {{ $data | mustToPrettyJson | nindent 10 -}}
-          {{ if ne (last $Sids) $sid }},{{ end -}}
-        {{ end }}
-        ]
-      }
+      {{- include "common-gitops.crossplane.awsPolicy" (dict "value" . "root" $root) | nindent 6 }}
     {{- end }}
     {{- include "common-gitops.tplvalues.render" (dict
       "value" (omit (.forProvider) "name" "tags" "document")

--- a/charts/iac/crossplane-aws-iam/templates/role.yaml
+++ b/charts/iac/crossplane-aws-iam/templates/role.yaml
@@ -13,10 +13,8 @@ metadata:
 spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
-    {{ with (.forProvider).assumeRolePolicyDocument -}}
     assumeRolePolicyDocument: |
-      {{- include "common-gitops.crossplane.awsPolicy" (dict "value" . "root" $root) | nindent 6 }}
-    {{- end }}
+      {{- include "common-gitops.crossplane.awsPolicy" (dict "value" .forProvider.assumeRolePolicyDocument "root" $root) | nindent 6 }}
     {{- include "common-gitops.tplvalues.render" (dict
       "value" (omit (.forProvider) "tags" "assumeRolePolicyDocument")
       "context" $root) | nindent 4 }}

--- a/charts/iac/crossplane-aws-iam/templates/role.yaml
+++ b/charts/iac/crossplane-aws-iam/templates/role.yaml
@@ -13,8 +13,24 @@ metadata:
 spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
+    {{ with (.forProvider).assumeRolePolicyDocument -}}
+    assumeRolePolicyDocument: |
+      {
+        "Version": "{{ .Version | default "2012-10-17" }}",
+        "Statement": [
+        {{- $Sids := keys .Statement | sortAlpha -}}
+        {{ $Statement := .Statement -}}
+        {{ range $sid := $Sids -}}
+          {{ $data := get $Statement $sid -}}
+          {{ $_ := set $data "Sid" $sid -}}
+          {{ $data | mustToPrettyJson | nindent 10 -}}
+          {{ if ne (last $Sids) $sid }},{{ end -}}
+        {{ end }}
+        ]
+      }
+    {{- end }}
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags")
+      "value" (omit (.forProvider) "tags" "assumeRolePolicyDocument")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.tags.list" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}

--- a/charts/iac/crossplane-aws-iam/templates/role.yaml
+++ b/charts/iac/crossplane-aws-iam/templates/role.yaml
@@ -15,19 +15,7 @@ spec:
   forProvider:
     {{ with (.forProvider).assumeRolePolicyDocument -}}
     assumeRolePolicyDocument: |
-      {
-        "Version": "{{ .Version | default "2012-10-17" }}",
-        "Statement": [
-        {{- $Sids := keys .Statement | sortAlpha -}}
-        {{ $Statement := .Statement -}}
-        {{ range $sid := $Sids -}}
-          {{ $data := get $Statement $sid -}}
-          {{ $_ := set $data "Sid" $sid -}}
-          {{ $data | mustToPrettyJson | nindent 10 -}}
-          {{ if ne (last $Sids) $sid }},{{ end -}}
-        {{ end }}
-        ]
-      }
+      {{- include "common-gitops.crossplane.awsPolicy" (dict "value" . "root" $root) | nindent 6 }}
     {{- end }}
     {{- include "common-gitops.tplvalues.render" (dict
       "value" (omit (.forProvider) "tags" "assumeRolePolicyDocument")

--- a/charts/iac/crossplane-aws-iam/values-test.yaml
+++ b/charts/iac/crossplane-aws-iam/values-test.yaml
@@ -72,25 +72,27 @@ Policy:
       deletionPolicy: Delete
       forProvider:
         description: "IAM Policy generated using crossplane + helm chart"
-        document: |-
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Action": [
-                  "route53:ChangeResourceRecordSets",
-                  "route53:ListResourceRecordSets"
-                ],
-                "Resource": "arn:aws:route53:::hostedzone/*"
-              },
-              {
-                "Effect": "Allow",
-                "Action": "route53:ListHostedZonesByName",
-                "Resource": "*"
-              }
-            ]
-          }
+        document:
+          Version: "2012-10-17"
+          Statement:
+            accountRead:
+              Effect: "Allow"
+              Action:
+                - "iam:GetAccountSummary"
+                - "iam:ListAccountAliases"
+                - "account:ListRegions"
+              Resource: "*"
+            route53RecordSets:
+              Effect: "Allow"
+              Action:
+                - "route53:ChangeResourceRecordSets"
+                - "route53:ListResourceRecordSets"
+              Resource: "arn:aws:route53:::hostedzone/*"
+            route53ListHostedZones:
+              Effect: "Allow"
+              Action:
+                - "route53:ListHostedZonesByName"
+              Resource: "*"
 
 Role:
   items:
@@ -101,19 +103,13 @@ Role:
       forProvider:
         description: "IAM Role generated using crossplane + helm chart"
         maxSessionDuration: 3600 # 1 to 12 hours
-        assumeRolePolicyDocument: |-
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                    "Service": "ec2.amazonaws.com"
-                },
-                "Action": "sts:AssumeRole"
-              }
-            ]
-          }
+        assumeRolePolicyDocument:
+          Statement:
+            _:
+              Effect: "Allow"
+              Principal:
+                Service: "ec2.amazonaws.com"
+              Action: "sts:AssumeRole"
 
 RolePolicyAttachment:
   items:

--- a/charts/shared/common-gitops/Chart.yaml
+++ b/charts/shared/common-gitops/Chart.yaml
@@ -25,4 +25,4 @@ name: common-gitops
 sources:
   - https://github.com/luminartech/helm-charts-public/charts/common-gitops
 type: library
-version: "1.0.4"
+version: "1.0.5"

--- a/charts/shared/common-gitops/templates/crossplane/_awsPolicy.tpl
+++ b/charts/shared/common-gitops/templates/crossplane/_awsPolicy.tpl
@@ -1,0 +1,49 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Render the policy Json from Yaml with support of templating in input.
+4 spaces are used for indentation as it's preffered by AWS
+Accepts dict:
+{
+  root: [map] - root context
+  value: [dict] - policy
+}
+Sample return:
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "iam:GetAccountSummary",
+                "iam:ListAccountAliases",
+                "account:ListRegions"
+            ],
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "accountRead"
+        },
+        {
+            "Action": "route53:ListHostedZonesByName",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "route53ListHostedZones"
+        }
+    ]
+}
+*/}}
+{{- define "common-gitops.crossplane.awsPolicy" -}}
+{
+    "Version": "{{ .value.Version | default "2012-10-17" }}",
+    "Statement": [
+    {{- $Statement := .value.Statement -}}
+    {{- /* List allows to find out inside the loop if the item is last and comma is not needed */ -}}
+    {{- $Sids := keys $Statement | sortAlpha -}}
+    {{ range $sid := $Sids -}}
+      {{ $stmt := get $Statement $sid -}}
+      {{ $_ := set $stmt "Sid" $sid -}}
+      {{ $json := $stmt | mustToPrettyJson | replace "  " "    " -}}
+      {{ include "common-gitops.tplvalues.render" (dict "value" $json "context" $.root) | nindent 8 -}}
+      {{ if ne (last $Sids) $sid }},{{ end -}}
+    {{ end }}
+    ]
+}
+{{- end -}}


### PR DESCRIPTION
Yaml:
- is easier to write, read and maintain for humans
- is shorter
- statements can be combined or overridden on different layers because they are stored as dict, not list (see values-test.yaml for an example)
- we can benefit from yaml syntax checker