### PR TITLE
Migrate crossplane-aws-s3 chart to upbound provider

### DIFF
--- a/charts/iac/crossplane-aws-s3/Chart.yaml
+++ b/charts/iac/crossplane-aws-s3/Chart.yaml
@@ -10,7 +10,7 @@ description: A Helm chart for crossplane AWS S3 resources
 name: crossplane-aws-s3
 # Below version must match the app version for the consistency.
 # Update minor bit if new tag is needed. e.g. 0.29.0-1
-version: "0.31.0-4"
+version: "0.31.0-5"
 home: https://helm-repo-public.luminarinfra.com
 sources:
   - https://github.com/luminartech/helm-charts-public/charts/crossplane-aws-s3
@@ -23,5 +23,5 @@ maintainers:
     email: hennadii.mykhailiuta@luminartech.com
 dependencies:
   - name: common-gitops
-    version: "1.0.4"
+    version: "1.0.6"
     repository: https://helm-repo-public.luminarinfra.com/

--- a/charts/iac/crossplane-aws-s3/README.md
+++ b/charts/iac/crossplane-aws-s3/README.md
@@ -17,10 +17,31 @@
 
 ### AWS resources
 
-| Name           | Description         | Value |
-| -------------- | ------------------- | ----- |
-| `Bucket`       | resource parameters | `{}`  |
-| `BucketPolicy` | resource parameters | `{}`  |
+| Name                                      | Description         | Value |
+| ----------------------------------------- | ------------------- | ----- |
+| `Bucket`                                  | resource parameters | `{}`  |
+| `BucketAccelerateConfiguration`           | resource parameters | `{}`  |
+| `BucketACL`                               | resource parameters | `{}`  |
+| `BucketAnalyticsConfiguration`            | resource parameters | `{}`  |
+| `BucketCorsConfiguration`                 | resource parameters | `{}`  |
+| `BucketIntelligentTieringConfiguration`   | resource parameters | `{}`  |
+| `BucketInventory`                         | resource parameters | `{}`  |
+| `BucketLifecycleConfiguration`            | resource parameters | `{}`  |
+| `BucketLogging`                           | resource parameters | `{}`  |
+| `BucketMetric`                            | resource parameters | `{}`  |
+| `BucketNotification`                      | resource parameters | `{}`  |
+| `BucketObject`                            | resource parameters | `{}`  |
+| `BucketObjectLockConfiguration`           | resource parameters | `{}`  |
+| `BucketOwnershipControls`                 | resource parameters | `{}`  |
+| `BucketPolicy`                            | resource parameters | `{}`  |
+| `BucketPublicAccessBlock`                 | resource parameters | `{}`  |
+| `BucketReplicationConfiguration`          | resource parameters | `{}`  |
+| `BucketRequestPaymentConfiguration`       | resource parameters | `{}`  |
+| `BucketServerSideEncryptionConfiguration` | resource parameters | `{}`  |
+| `BucketVersioning`                        | resource parameters | `{}`  |
+| `BucketWebsiteConfiguration`              | resource parameters | `{}`  |
+| `Object`                                  | resource parameters | `{}`  |
+| `ObjectCopy`                              | resource parameters | `{}`  |
 
 
 ## Configuration and installation details

--- a/charts/iac/crossplane-aws-s3/templates/bucketIntelligenttieringconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketIntelligenttieringconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketIntelligentTieringConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketaccelerateconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketaccelerateconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketAccelerateConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketacl.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketacl.yaml
@@ -1,10 +1,10 @@
-{{- $kind := "BucketPolicy" -}}
+{{- $kind := "BucketACL" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
   {{- if hasKey $item "enabled" | ternary ($item.enabled) (ne $kindObj.enabled false) }}
 ---
-apiVersion: s3.aws.crossplane.io/v1alpha3
+apiVersion: s3.aws.upbound.io/v1beta1
 kind: {{ $kind }}
 metadata:
   name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" .name) }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketanalyticsconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketanalyticsconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketAnalyticsConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketcorsconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketcorsconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketCorsConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketinventory.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketinventory.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketInventory" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketlifecycleconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketlifecycleconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketLifecycleConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketlogging.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketlogging.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketLogging" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketmetric.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketmetric.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketMetric" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketnotification.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketnotification.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketNotification" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketobject.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketobject.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketObject" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}

--- a/charts/iac/crossplane-aws-s3/templates/bucketobjectlockconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketobjectlockconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketObjectLockConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketownershipcontrols.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketownershipcontrols.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketOwnershipControls" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketpolicy.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketpolicy.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketPolicy" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -13,11 +13,12 @@ metadata:
 spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
+    policy: |
+      {{- include "common-gitops.crossplane.awsPolicy" (dict "value" .forProvider.policy "root" $root) | nindent 6 }}
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region" "policy")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketpublicaccessblock.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketpublicaccessblock.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketPublicAccessBlock" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketreplicationconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketreplicationconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketReplicationConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketrequestpaymentconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketrequestpaymentconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketRequestPaymentConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketserversideencryptionconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketserversideencryptionconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketServerSideEncryptionConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketversioning.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketversioning.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketVersioning" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/bucketwebsiteconfiguration.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/bucketwebsiteconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "BucketWebsiteConfiguration" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}
@@ -14,10 +14,9 @@ spec:
     {{- include "common-gitops.crossplane.awsDeletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
   forProvider:
     {{- include "common-gitops.tplvalues.render" (dict
-      "value" (omit (.forProvider) "tags" "region")
+      "value" (omit (.forProvider) "region")
       "context" $root) | nindent 4 }}
     {{- include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind) | nindent 4 }}
-    {{- include "common-gitops.tags.dict" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 4 }}
     {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
     {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}

--- a/charts/iac/crossplane-aws-s3/templates/object.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/object.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "Object" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}

--- a/charts/iac/crossplane-aws-s3/templates/objectcopy.yaml
+++ b/charts/iac/crossplane-aws-s3/templates/objectcopy.yaml
@@ -1,4 +1,4 @@
-{{- $kind := "Bucket" -}}
+{{- $kind := "ObjectCopy" -}}
 {{- $root := . -}}
 {{- $kindObj := or (get $root.Values $kind) (dict) -}}
 {{- range $name, $item := $kindObj.items -}}

--- a/charts/iac/crossplane-aws-s3/values-test.yaml
+++ b/charts/iac/crossplane-aws-s3/values-test.yaml
@@ -5,126 +5,333 @@
 ##############
 # global:
 #   chartNameOverride: "infra"
-
 #   releaseNameOverride: "infra"
-
 #   tags: {}
-  # tags:
-  #   - key: k1
-  #     value: v1
-
-  # labels: {}
-
-  # Annotations to be added to the published metadata secret
-  # annotations: {}
-
-  # aws provider configmap
-  # providerConfigRef:
-  #   name: aws-provider-cicd
 
 Bucket:
-  enabled: true
   items:
-    test-bucket:
-      deletionPolicy: Delete
-      annotations:
-        # This will be the actual bucket name. It must be globally unique, so you
-        # probably want to change it before trying to apply this example.
-        crossplane.io/external-name: lt-test-bucket-22
+    _:
       forProvider:
+        region: us-west-1
+        objectLockEnabled: true
+        tags:
+          Name: SampleBucket
+
+BucketAccelerateConfiguration:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: example
+        status: Enabled
+
+BucketACL:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3-canned
         acl: private
-        locationConstraint: us-east-1
-        publicAccessBlockConfiguration:
-          blockPublicPolicy: true
-        accelerateConfiguration:
-          status: Enabled
-        versioningConfiguration:
-          status: Enabled
-        tagging:
-          tagSet:
-            - key: key1
-              value: val1
-            - key: secondKey
-              value: val2
-            - key: key3
-              value: val3
-        objectLockEnabledForBucket: false
-        serverSideEncryptionConfiguration:
-          rules:
-            - applyServerSideEncryptionByDefault:
-                sseAlgorithm: AES256
-        corsConfiguration:
-          corsRules:
-            - allowedMethods:
-                - "GET"
-              allowedOrigins:
-                - "*"
-              allowedHeaders:
-                - "*"
-              exposeHeaders:
-                - "x-amz-server-side-encryption"
-        lifecycleConfiguration:
-          rules:
-            - status: Enabled
-              filter:
-                prefix: "ola/"
-              expiration:
-                days: 15
-        replicationConfiguration:
-          roleRef:
-            name: somerole
-          rules:
-            - destination:
-                storageClass: STANDARD
-                bucketRef:
-                  name: repl-dest
-              deleteMarkerReplication:
-                status: Disabled
-              filter:
-                prefix: ""
-              priority: 0
-              id: rule-1
-              status: Enabled
-BucketPolicy:
-  enabled: true
+
+BucketAnalyticsConfiguration:
   items:
-    test-bucket-policy:
-      deletionPolicy: Delete
+    _:
       forProvider:
-        region: us-east-1
-        bucketNameRef:
-          name: test-bucket
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        name: EntireBucket
+        storageClassAnalysis:
+        - dataExport:
+          - destination:
+            - s3BucketDestination:
+              - bucketArnSelector:
+                  matchLabels:
+                    testing.upbound.io/example-name: s3
+
+BucketCorsConfiguration:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        corsRule:
+        - allowedHeaders:
+          - '*'
+          allowedMethods:
+          - PUT
+          - POST
+          allowedOrigins:
+          - https://s3-website-test.upbound.com
+          exposeHeaders:
+          - ETag
+          maxAgeSeconds: 3000
+        - allowedMethods:
+          - GET
+          allowedOrigins:
+          - '*'
+
+BucketIntelligentTieringConfiguration:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        name: EntireBucket
+        tiering:
+        - accessTier: DEEP_ARCHIVE_ACCESS
+          days: 180
+        - accessTier: ARCHIVE_ACCESS
+          days: 125
+
+BucketInventory:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        destination:
+        - bucket:
+          - bucketArnSelector:
+              matchLabels:
+                testing.upbound.io/example-name: s3-2
+            format: ORC
+        includedObjectVersions: All
+        name: EntireBucketDaily
+        schedule:
+        - frequency: Daily
+
+BucketLifecycleConfiguration:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        rule:
+          - id: rule-1
+            status: Enabled
+            filter:
+              - prefix: "tmp/"
+            expiration:
+              - days: 90
+
+BucketLogging:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        targetBucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3-2
+        targetPrefix: log/
+
+BucketMetric:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        name: EntireBucket
+
+BucketNotification:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        topic:
+        - events:
+          - "s3:ObjectCreated:*"
+          filterSuffix: ".log"
+          topicArnSelector:
+            matchLabels:
+              testing.upbound.io/example-name: s3
+
+BucketObject:
+  items:
+    _:
+      forProvider:
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        key: new_object_key
+        region: us-west-1
+        contentBase64: dGhpcyBpcyBhIHRleHQg
+
+BucketObjectLockConfiguration:
+  items:
+    _:
+      forProvider:
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        region: us-west-1
+        rule:
+        - defaultRetention:
+          - days: 5
+            mode: COMPLIANCE
+
+BucketOwnershipControls:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        rule:
+        - objectOwnership: BucketOwnerPreferred
+
+BucketPolicy:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
         policy:
-          version: '2012-10-17'
-          statements:
-            - action:
-                - s3:ListBucket
-                - s3:GetBucketLocation
-                - s3:ListBucketMultipartUploads
-                - s3:PutBucketCORS
-              effect: Allow
-              principal:
-                awsPrincipals:
-                  - iamUserArnSelector:
-                      matchLabels:
-                        example: "true"
-              resource:
-                # This is unfortunately not currently able to be inferred from a
-                # reference to test-bucket, and must therefore be set to the ARN of
-                # test-bucket (i.e. its actual external name).
-                - "arn:aws:s3:::crossplane-example-bucket"
-              condition:
-              - operatorKey: StringEquals
-                conditions:
-                  - key: "aws:Key1"
-                    stringValue: "value1"
-                  - key: "aws:Key2"
-                    stringValue: "value2"
-              - operatorKey: IpAddress
-                conditions:
-                  - key: "aws:SourceIp"
-                    stringValue: "192.0.2.0/24"
-              - operatorKey: NotIpAddress
-                conditions:
-                  - key: "aws:SourceIp"
-                    stringValue: "192.0.2.188/32"
+          Statement:
+            VisualEditor0:
+              Effect: "Allow"
+              Principal: "*"
+              Action:
+                - "s3:GetObject"
+                - "s3:ListBucket"
+              Resource:
+                - "arn:aws:s3:::<bucket name>"
+                - "arn:aws:s3:::<bucket name>/*"
+
+BucketPublicAccessBlock:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        blockPublicAcls: false
+        blockPublicPolicy: false
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+
+BucketReplicationConfiguration:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        role: <role ARN>
+        rule:
+        - destination:
+          - bucketSelector:
+              matchLabels:
+                testing.upbound.io/example-name: s3
+            storageClass: STANDARD
+          filter:
+          - prefix: foo
+          id: foobar
+          deleteMarkerReplication:
+          - status: Enabled
+          status: Enabled
+
+BucketRequestPaymentConfiguration:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        payer: Requester
+
+BucketServerSideEncryptionConfiguration:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        rule:
+        - applyServerSideEncryptionByDefault:
+          - kmsMasterKeyIdSelector:
+              matchLabels:
+                testing.upbound.io/example-name: s3
+            sseAlgorithm: aws:kms
+
+BucketVersioning:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        versioningConfiguration:
+        - status: Enabled
+
+BucketWebsiteConfiguration:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        errorDocument:
+        - key: error.html
+        indexDocument:
+        - suffix: index.html
+        routingRule:
+        - condition:
+          - keyPrefixEquals: docs/
+          redirect:
+          - replaceKeyPrefixWith: documents/
+
+Object:
+  items:
+    _:
+      forProvider:
+        region: us-west-1
+        bucketSelector:
+          matchLabels:
+            testing.upbound.io/example-name: s3
+        key: object_key
+        contentBase64: dGhpcyBpcyBhIHRleHQg
+      providerConfigRef:
+        name: default
+
+ObjectCopy:
+  items:
+    _:
+      forProvider:
+        bucket: destination_bucket_name
+        grant:
+        - permissions:
+          - READ
+          type: Group
+          uri: http://acs.amazonaws.com/groups/global/AllUsers
+        key: file_name
+        region: us-west-1
+        source: source_bucket_name/file_name

--- a/charts/iac/crossplane-aws-s3/values.yaml
+++ b/charts/iac/crossplane-aws-s3/values.yaml
@@ -1,10 +1,93 @@
 ## @section AWS resources
 
-
 ## @param Bucket resource parameters
 ##
 Bucket: {}
 
+## @param BucketAccelerateConfiguration resource parameters
+##
+BucketAccelerateConfiguration: {}
+
+## @param BucketACL resource parameters
+##
+BucketACL: {}
+
+## @param BucketAnalyticsConfiguration resource parameters
+##
+BucketAnalyticsConfiguration: {}
+
+## @param BucketCorsConfiguration resource parameters
+##
+BucketCorsConfiguration: {}
+
+## @param BucketIntelligentTieringConfiguration resource parameters
+##
+BucketIntelligentTieringConfiguration: {}
+
+## @param BucketInventory resource parameters
+##
+BucketInventory: {}
+
+## @param BucketLifecycleConfiguration resource parameters
+##
+BucketLifecycleConfiguration: {}
+
+## @param BucketLogging resource parameters
+##
+BucketLogging: {}
+
+## @param BucketMetric resource parameters
+##
+BucketMetric: {}
+
+## @param BucketNotification resource parameters
+##
+BucketNotification: {}
+
+## @param BucketObject resource parameters
+##
+BucketObject: {}
+
+## @param BucketObjectLockConfiguration resource parameters
+##
+BucketObjectLockConfiguration: {}
+
+## @param BucketOwnershipControls resource parameters
+##
+BucketOwnershipControls: {}
+
 ## @param BucketPolicy resource parameters
 ##
 BucketPolicy: {}
+
+## @param BucketPublicAccessBlock resource parameters
+##
+BucketPublicAccessBlock: {}
+
+## @param BucketReplicationConfiguration resource parameters
+##
+BucketReplicationConfiguration: {}
+
+## @param BucketRequestPaymentConfiguration resource parameters
+##
+BucketRequestPaymentConfiguration: {}
+
+## @param BucketServerSideEncryptionConfiguration resource parameters
+##
+BucketServerSideEncryptionConfiguration: {}
+
+## @param BucketVersioning resource parameters
+##
+BucketVersioning: {}
+
+## @param BucketWebsiteConfiguration resource parameters
+##
+BucketWebsiteConfiguration: {}
+
+## @param Object resource parameters
+##
+Object: {}
+
+## @param ObjectCopy resource parameters
+##
+ObjectCopy: {}


### PR DESCRIPTION
Community aws provider does not seem to support buckets with disabled ACLs and upbound provider has much more features.