### PR TITLE
Make the name of the secret returned by PublishConnectionsDetailsTo configurable

### DIFF
--- a/charts/shared/common-gitops/Chart.yaml
+++ b/charts/shared/common-gitops/Chart.yaml
@@ -25,4 +25,4 @@ name: common-gitops
 sources:
   - https://github.com/luminartech/helm-charts-public/charts/common-gitops
 type: library
-version: "1.1.0"
+version: "1.1.1"

--- a/charts/shared/common-gitops/templates/crossplane/_publishConnectionDetailsTo.tpl
+++ b/charts/shared/common-gitops/templates/crossplane/_publishConnectionDetailsTo.tpl
@@ -25,7 +25,7 @@ publishConnectionDetailsTo:
                  (($root.Values.global).publishConnectionDetailsTo) -}}
     {{- if .enabled -}}
 publishConnectionDetailsTo:
-  name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" $.nameOverride) }}
+  name: {{ include "common-gitops.tplvalues.render" (dict "value" .name "context" $root) | default (include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" $.nameOverride)) }}
       {{- with .configRef }}
   configRef:
     name: {{ include "common-gitops.tplvalues.render" (dict "value" .name "context" $root) | default "default" }}


### PR DESCRIPTION
It's handy to be able to override the generated secret name.