### PR TITLE
Trigger aws-ecr chart release

### DIFF
--- a/charts/iac/crossplane-aws-ecr/Chart.yaml
+++ b/charts/iac/crossplane-aws-ecr/Chart.yaml
@@ -10,7 +10,7 @@ description: A Helm chart for crossplane AWS ECR resources
 name: crossplane-aws-ecr
 # Below version must match the app version for the consistency.
 # Update minor bit if new tag is needed. e.g. 0.28.0-1
-version: "0.37.0-0"
+version: "0.37.0-1"
 home: https://helm-repo-public.luminarinfra.com
 sources:
   - https://github.com/luminartech/helm-charts-public


### PR DESCRIPTION
aws-ecr chart v.0.37.0-0 is stuck in limbo state. Increment the version to trigger a new release.