### PR TITLE
Update crossplane-karpenter dependencies

### DIFF
--- a/charts/iac/crossplane-kubernetes/Chart.yaml
+++ b/charts/iac/crossplane-kubernetes/Chart.yaml
@@ -7,7 +7,7 @@ description: A Helm chart for crossplane Kubernetes resources
 name: crossplane-kubernetes
 # Below version must match the app version for the consistency.
 # Update minor bit if new tag is needed. e.g. 0.3.0-1
-version: "0.4.0-3"
+version: "0.4.0-4"
 home: https://helm-repo-public.luminarinfra.com
 sources:
   - https://github.com/luminartech/helm-charts-public/
@@ -20,5 +20,5 @@ maintainers:
     email: hennadii.mykhailiuta@luminartech.com
 dependencies:
   - name: common-gitops
-    version: "1.0.4"
+    version: "1.1.3"
     repository: https://helm-repo-public.luminarinfra.com/


### PR DESCRIPTION
Version 1.1.0 of common-gitops helm chart introduced a breaking change so it's not possible to use charts together that depend on different major releases of common-gitops.