### PR TITLE
Use correct syntax for providerConfig

### DIFF
--- a/charts/modules/infra/aws-eks-rbac/Chart.yaml
+++ b/charts/modules/infra/aws-eks-rbac/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: "0.37.0"
 description: A Helm chart for IAC resources needed to access EKS cluster
 name: aws-eks-rbac
-version: "0.37.0-6"
+version: "0.37.0-7"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/infra/aws-eks-rbac

--- a/charts/modules/infra/aws-eks-rbac/README.md
+++ b/charts/modules/infra/aws-eks-rbac/README.md
@@ -53,6 +53,8 @@
 
 
 
+
+
 ## Configuration and installation details
 
 

--- a/charts/modules/infra/aws-eks-rbac/README.md
+++ b/charts/modules/infra/aws-eks-rbac/README.md
@@ -51,6 +51,8 @@
 
 
 
+
+
 ## Configuration and installation details
 
 

--- a/charts/modules/infra/aws-eks-rbac/values.yaml
+++ b/charts/modules/infra/aws-eks-rbac/values.yaml
@@ -142,18 +142,15 @@ crossplane-kubernetes:
   enabled: false
   ## @skip crossplane-kubernetes.ProviderConfig
   ProviderConfig:
-    enabled: false
     items:
       # Can not move it to crossplane-provider because it depends on particular secret
       _:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
-        spec:
-          credentials:
-            secretRef:
-              key: "kubeconfig"
-              name: '{{ include "common-gitops.names.release" . }}'
-              namespace: '{{ .Values.global.crossplaneNamespace }}'
-            source: Secret
+        credentials:
+          secretRef:
+            key: "kubeconfig"
+            name: '{{ include "common-gitops.names.release" . }}'
+            namespace: '{{ .Values.global.crossplaneNamespace }}'
+          source: Secret
   ## @skip crossplane-kubernetes.Object
   Object:
     items:


### PR DESCRIPTION
Syntax of ProviderConfig in crossplane-kubernetes was changed to comply with other IAC charts, i.e. ignore "spec" key. Update dependent module.