### PR TITLE
gitops/IPE-1423-crossplane-aws-s3-BucketReplicationConfiguration

### DIFF
--- a/charts/iac/crossplane-aws-s3/templates/bucket-replication-configuration
+++ b/charts/iac/crossplane-aws-s3/templates/bucket-replication-configuration
@@ -1,0 +1,22 @@
+{{- $kind := "BucketReplicationConfiguration" -}}
+{{- $root := . -}}
+{{- $kindObj := or (get $root.Values $kind) (dict) -}}
+{{- range $name, $item := $kindObj.items -}}
+  {{- if hasKey $item "enabled" | ternary ($item.enabled) (ne $kindObj.enabled false) }}
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: {{ $kind }}
+metadata:
+  name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" .name) }}
+    {{- include "common-gitops.labels" (dict "root" $root "name" $name "kind" $kind) | trim | nindent 2 }}
+    {{- include "common-gitops.annotations" (dict "root" $root "name" $name "kind" $kind) | trim | nindent 2 }}
+spec:
+    {{- include "common-gitops.crossplane.deletionPolicy" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
+    {{- include "common-gitops.crossplane.forProvider" (dict "root" $root "values" (.forProvider) "valuesOverride" (dict
+      "region" (include "common-gitops.crossplane.awsRegion" (dict "root" $root "name" $name "kind" $kind))
+      )) | nindent 2 }}
+    {{- include "common-gitops.crossplane.publishConnectionDetailsTo" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
+    {{- include "common-gitops.crossplane.writeConnectionSecretToRef" (dict "root" $root "name" $name "kind" $kind "nameOverride" .name) | nindent 2 }}
+    {{- include "common-gitops.crossplane.providerConfigRef" (dict "root" $root "name" $name "kind" $kind) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/iac/crossplane-aws-s3/values.yaml
+++ b/charts/iac/crossplane-aws-s3/values.yaml
@@ -80,6 +80,10 @@ BucketServerSideEncryptionConfiguration: {}
 ##
 BucketVersioning: {}
 
+## @param BucketReplicationConfiguration resource parameters
+##
+BucketReplicationConfiguration: {}
+
 ## @param BucketWebsiteConfiguration resource parameters
 ##
 BucketWebsiteConfiguration: {}


### PR DESCRIPTION
**Why this change?**

Add required BucketReplicationConfiguration CRD to crossplane-aws-s3 module