### PR TITLE
chore(crossplane): use default apiVersion for crossplane resources

### DIFF
--- a/charts/modules/apps/crossplane/Chart.yaml
+++ b/charts/modules/apps/crossplane/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "1.13.2"
 description: A Helm chart for Crossplane
 name: crossplane
-version: "1.13.2-24"
+version: "1.13.2-25"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/crossplane
@@ -25,5 +25,5 @@ dependencies:
     repository: https://helm-repo-public.luminarinfra.com/
     condition: crossplane-aws-iam.enabled
   - name: common-gitops
-    version: "1.1.3"
+    version: "1.1.5"
     repository: https://helm-repo-public.luminarinfra.com/

--- a/charts/modules/apps/crossplane/templates/provider-config.yaml
+++ b/charts/modules/apps/crossplane/templates/provider-config.yaml
@@ -4,7 +4,7 @@
 {{- range $name, $item := $kindObj.items -}}
   {{- if hasKey $item "enabled" | ternary ($item.enabled) (ne $kindObj.enabled false) }}
 ---
-apiVersion: {{ .apiVersion | required "apiVersion is required" }}
+apiVersion: {{ .apiVersion | default "aws.upbound.io/v1alpha1" }}
 kind: ProviderConfig
 metadata:
   name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" .name) }}

--- a/charts/modules/apps/crossplane/templates/storeconfig.yaml
+++ b/charts/modules/apps/crossplane/templates/storeconfig.yaml
@@ -4,7 +4,7 @@
 {{- range $name, $item := $kindObj.items -}}
   {{- if hasKey $item "enabled" | ternary ($item.enabled) (ne $kindObj.enabled false) }}
 ---
-apiVersion: {{ .apiVersion | required "apiVersion is required" }}
+apiVersion: {{ .apiVersion | default "aws.upbound.io/v1alpha1" }}
 kind: {{ $kind }}
 metadata:
   name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" .name) }}

--- a/charts/modules/apps/crossplane/values.yaml
+++ b/charts/modules/apps/crossplane/values.yaml
@@ -177,17 +177,9 @@ ProviderConfig:
   ## items._: Name of the resource in the kubernetes. "_" generates a default name as releaseName-object name
   ## ref: https://github.com/luminartech/helm-charts-public/blob/478ec718b93063f1eccfa591189ab0f59bf3fd1e/charts/shared/common-gitops/templates/_names.tpl#L50
   items:
-    'aws-{{ .Values.global.awsAccountId }}':
-      enabled: false
-      name: 'aws-{{ .Values.global.awsAccountId }}'
-      apiVersion: aws.upbound.io/v1beta1
-      spec:
-        credentials:
-          source: IRSA
     aws:
       enabled: false
       name: aws
-      apiVersion: aws.upbound.io/v1beta1
       spec:
         credentials:
           source: IRSA
@@ -205,7 +197,6 @@ StoreConfig:
     aws:
       enabled: false
       name: aws
-      apiVersion: aws.upbound.io/v1alpha1
       spec:
         defaultScope: '{{ .Values.global.crossplaneNamespace }}'
         type: Kubernetes


### PR DESCRIPTION
- Using variables in itemIDs is not yet supported by gitops-common. Removing something that can not be used.
- Set default apiVersion for some resources to save few lines of code.