### PR TITLE
gitops/IPE-1538-chart-version-update

### DIFF
--- a/charts/modules/apps/crossplane/Chart.yaml
+++ b/charts/modules/apps/crossplane/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "1.13.2"
 description: A Helm chart for Crossplane
 name: crossplane
-version: "1.13.2-25"
+version: "1.13.2-26"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/crossplane


### PR DESCRIPTION
**Why this change?**

Missed to update the chart version.