### PR TITLE
feat(gitops-common): Add itemEnabled template

### DIFF
--- a/charts/shared/common-gitops/Chart.yaml
+++ b/charts/shared/common-gitops/Chart.yaml
@@ -25,4 +25,4 @@ name: common-gitops
 sources:
   - https://github.com/luminartech/helm-charts-public/charts/common-gitops
 type: library
-version: "1.1.5"
+version: "1.1.6"

--- a/charts/shared/common-gitops/templates/_utils.tpl
+++ b/charts/shared/common-gitops/templates/_utils.tpl
@@ -55,3 +55,25 @@ Returns string:
     {{- fail "Netmask is expected to be a number >= 8 and <=30" -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Compute the logic of item enabled/disabled state.
+
+Input dict:
+{
+  root: [map] - root context
+  kind: [string] - resource kind name, e.g. "Policy"
+  name: [string] - item id, e.g. "argocd"
+}
+Sample return (always string):
+true
+*/}}
+{{- define "common-gitops.utils.itemEnabled" -}}
+  {{- $kindObj := (get (.root.Values) .kind) -}}
+  {{- $item := (get $kindObj.items .name) -}}
+  {{- hasKey $item "enabled" | ternary
+      (eq (include "common-gitops.tplvalues.render" (
+        dict "value" ($item.enabled | toString) "context" .root)) "true")
+      (ne (include "common-gitops.tplvalues.render" (
+        dict "value" ($kindObj.enabled | toString) "context" .root)) "false") }}
+{{- end -}}


### PR DESCRIPTION
Render "enabled" value as golang template. Should still be backward compatible with existing code in values.yaml files.