### PR TITLE
EKS: Avoid critical VPC routes getting deleted

### DIFF
--- a/charts/modules/infra/aws-vpc/Chart.yaml
+++ b/charts/modules/infra/aws-vpc/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: "0.41.0"
 description: A Helm chart for IAC resources needed by VPC
 name: aws-vpc
-version: "0.41.0"
+version: "0.41.1"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/infra/aws-vpc

--- a/charts/modules/infra/aws-vpc/values.yaml
+++ b/charts/modules/infra/aws-vpc/values.yaml
@@ -290,6 +290,7 @@ crossplane-aws-ec2:
     enabled: true
     items:
       private-default:
+        deletionPolicy: Orphan
         forProvider:
           destinationCidrBlock: "0.0.0.0/0"
           natGatewayIdRef:
@@ -297,6 +298,7 @@ crossplane-aws-ec2:
           routeTableIdRef:
             name: '{{ include "common-gitops.names.release" . }}-private'
       public-default:
+        deletionPolicy: Orphan
         forProvider:
           destinationCidrBlock: "0.0.0.0/0"
           gatewayIdRef:


### PR DESCRIPTION
**What this change will do?**

This PR will protect the critical default routes from getting deleted and mark them orphan if crossplane resources are deleted. 