### PR TITLE
loki-scalable-values-fix

### DIFF
--- a/charts/modules/apps/loki-scalable/Chart.yaml
+++ b/charts/modules/apps/loki-scalable/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "4.6.1"
 description: A wrapper Helm chart for loki scalable
 name: loki-scalable
-version: "4.6.1-2"
+version: "4.6.1-3"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/loki-scalable

--- a/charts/modules/apps/loki-scalable/README.md
+++ b/charts/modules/apps/loki-scalable/README.md
@@ -42,6 +42,8 @@
 
 
 
+
+
 ## Configuration and installation details
 
 

--- a/charts/modules/apps/loki-scalable/values.yaml
+++ b/charts/modules/apps/loki-scalable/values.yaml
@@ -168,7 +168,7 @@ crossplane-aws-iam:
                   Federated: arn:aws:iam::{{ .Values.global.awsAccountId }}:oidc-provider/oidc.eks.{{ .Values.global.awsRegion }}.amazonaws.com/id/{{ .Values.global.eksHash }}
                 Condition:
                   StringEquals:
-                    "oidc.eks.{{ .Values.global.awsRegion }}.amazonaws.com/id/{{ .Values.global.eksHash }}:sub": system:serviceaccount:{{ include "common-gitops.names.namespace" . }}:{{ .Values.global.deploymentName }}
+                    "oidc.eks.{{ .Values.global.awsRegion }}.amazonaws.com/id/{{ .Values.global.eksHash }}:sub": system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.global.deploymentName }}
                     "oidc.eks.{{ .Values.global.awsRegion }}.amazonaws.com/id/{{ .Values.global.eksHash }}:aud": sts.amazonaws.com
               allowEC2AssumeRole:
                 Effect: Allow


### PR DESCRIPTION
There is a bug in common-gitops namespace function. To unblock the promtail related change, setting the namespace to value where the chart is installed.  