### PR TITLE
fix(common-gitops): support no input for some parameters

### DIFF
--- a/charts/shared/common-gitops/Chart.yaml
+++ b/charts/shared/common-gitops/Chart.yaml
@@ -27,4 +27,4 @@ name: common-gitops
 sources:
   - https://github.com/luminartech/helm-charts-public/charts/shared/common-gitops
 type: library
-version: "1.1.8"
+version: "1.1.9"

--- a/charts/shared/common-gitops/templates/crossplane/_publishConnectionDetailsTo.tpl
+++ b/charts/shared/common-gitops/templates/crossplane/_publishConnectionDetailsTo.tpl
@@ -29,7 +29,11 @@ publishConnectionDetailsTo:
     default (include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" $.nameOverride)) }}
       {{- with .configRef }}
   configRef:
-    name: {{ include "common-gitops.tplvalues.render" (dict "value" .name "context" $root) | default "default" }}
+        {{- with .name }}
+    name: {{ include "common-gitops.tplvalues.render" (dict "value" . "context" $root) }}
+        {{ else -}}
+    name: default
+        {{ end -}}
         {{- with .policy }}
     policy:
           {{- include "common-gitops.tplvalues.render" (dict "value" . "context" $root) | nindent 6 -}}

--- a/charts/shared/common-gitops/templates/crossplane/_writeConnectionSecretToRef.tpl
+++ b/charts/shared/common-gitops/templates/crossplane/_writeConnectionSecretToRef.tpl
@@ -20,13 +20,19 @@ writeConnectionSecretToRef:
   {{- /* Left argument takes precedence over the right one */ -}}
   {{- with merge ($item.writeConnectionSecretToRef)
                  ($kindObj.writeConnectionSecretToRef)
-                 ((.root.Values.global).writeConnectionSecretToRef) -}}
+                 (($root.Values.global).writeConnectionSecretToRef) -}}
     {{- if .enabled }}
 writeConnectionSecretToRef:
-  name: {{ include "common-gitops.tplvalues.render" (dict "value" .name "context" $root) |
-    default (include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" $.nameOverride)) }}
-  namespace: {{ include "common-gitops.tplvalues.render" (dict "value" .namespace "context" $root) |
-    default "infra-crossplane" }}
+      {{- with .name }}
+  name: {{ include "common-gitops.tplvalues.render" (dict "value" . "context" $root) | quote }}
+      {{- else }}
+  name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" $.nameOverride) | quote }}
+      {{- end }}
+      {{- with .namespace }}
+  namespace: {{ include "common-gitops.tplvalues.render" (dict "value" . "context" $root) | quote }}
+      {{- else }}
+  namespace: "infra-crossplane"
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
common-gitops.tplvalues.render returns null if the input is empty so it can not be used with default function