### PR TITLE
feat(crossplane): Use default poll and sync intervals

### DIFF
--- a/charts/modules/apps/crossplane/Chart.yaml
+++ b/charts/modules/apps/crossplane/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   repository: oci://ghcr.io/luminartech/helm-charts-public
   version: 1.1.7
 home: "https://github.com/luminartech/helm-charts-public"
-version: 1.14.5-4
+version: 1.14.5-6
 sources:
 - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/crossplane
 maintainers:

--- a/charts/modules/apps/crossplane/README.md
+++ b/charts/modules/apps/crossplane/README.md
@@ -32,7 +32,6 @@
 | `global.crossplaneIAMRole`         | Crossplane AWS IAM role with administrative permissions to create cloud resources                                        | `crossplane-provider-aws`        |
 | `global.crossplaneNamespace`       | Crossplane namespace                                                                                                     | `infra-crossplane`               |
 
-
 ### Crossplane configurations
 
 | Name                       | Description                                | Value   |
@@ -42,20 +41,17 @@
 | `StoreConfig.enabled`      | Toggle for enabling or disabling template. | `false` |
 | `Provider.enabled`         | Toggle for enabling or disabling template. | `false` |
 
-
 ### Dependency: crossplane upstream helm chart parameters.
 
 | Name                 | Description                                                | Value   |
 | -------------------- | ---------------------------------------------------------- | ------- |
 | `crossplane.enabled` | Toggle for enabling or disabling upstream chart templates. | `false` |
 
-
 ### Dependency: prometheus-service-discovery upstream helm chart parameters for creating serviceMonitors and podMonitors.
 
 | Name                                   | Description                                                | Value   |
 | -------------------------------------- | ---------------------------------------------------------- | ------- |
 | `prometheus-service-discovery.enabled` | Toggle for enabling or disabling upstream chart templates. | `false` |
-
 
 ### Dependency: crossplane-aws-iam upstream helm chart parameters for creating and self managing crossplane IAM role
 

--- a/charts/modules/apps/crossplane/values.yaml
+++ b/charts/modules/apps/crossplane/values.yaml
@@ -76,8 +76,6 @@ ControllerConfig:
           - --enable-external-secret-stores
           - --provider-ttl=250
           - --max-reconcile-rate=10
-          - --sync=48h
-          - --poll=48h
         podSecurityContext:
           fsGroup: 2000
         resources:
@@ -102,8 +100,6 @@ ControllerConfig:
           - --enable-external-secret-stores
           - --provider-ttl=250
           - --max-reconcile-rate=10
-          - --sync=48h
-          - --poll=48h
         podSecurityContext:
           fsGroup: 2000
         resources:
@@ -128,8 +124,6 @@ ControllerConfig:
           - --enable-external-secret-stores
           - --provider-ttl=250
           - --max-reconcile-rate=5
-          - --sync=48h
-          - --poll=48h
         podSecurityContext:
           fsGroup: 2000
         resources:
@@ -154,8 +148,6 @@ ControllerConfig:
           - --enable-external-secret-stores
           - --provider-ttl=250
           - --max-reconcile-rate=3
-          - --sync=48h
-          - --poll=48h
         podSecurityContext:
           fsGroup: 2000
         resources:


### PR DESCRIPTION
> The poll option determines how often the provider will compare the desired Workspace configuration with the actual deployed resources (terraform plan) and reconcile any differences (terraform apply). The default value is 10m. Shorter poll intervals increase the load on the provider by reconciling existing Workspaces more often to allow for faster reconciliation of differences, but this can cause the provider to take longer to process new Workspace objects that are created. Longer poll intervals will reduce the load on the provider by reconciling existing Workspaces less often, taking a longer time to identify and reconcile differences, but also shortening the amount of time required for the provider to respond to new Workspaces.

For `--sync` parameter the best explanation I could find is the code: https://github.com/crossplane/upjet-provider-template/blob/ff852aca552ccc12e18c11e41752bec3b2f1f64a/cmd/provider/main.go#L41C3-L41C13.

We have increased these options to lower the load on crossplane but I've noticed that it sometimes is very challenging to eliminate drift.