### PR TITLE
osrm-nominatim-default-resource-limits

### DIFF
--- a/charts/modules/apps/osrm-nominatim/values.yaml
+++ b/charts/modules/apps/osrm-nominatim/values.yaml
@@ -52,17 +52,17 @@ nominatimInitialize:
   threads: 16
   freeze: false
   wikipediaUrl: https://nominatim.org/data/wikimedia-importance.sql.gz
-  resources: {}
+  resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-#    requests:
-#      cpu: 4000m
-#      memory: 4Gi
-#    limits:
-#      cpu: 4000m
-#      memory: 4Gi
+   requests:
+     cpu: 4000m
+     memory: 4Gi
+   limits:
+     cpu: 4000m
+     memory: 4Gi
 
 nominatimReplications:
   enabled: false
@@ -73,13 +73,13 @@ nominatimReplications:
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following
 # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  resources: {}
-#    requests:
-#      cpu: 2000m
-#      memory: 2Gi
-#    limits:
-#      cpu: 2000m
-#      memory: 2Gi
+  resources:
+   requests:
+     cpu: 2000m
+     memory: 2Gi
+   limits:
+     cpu: 2000m
+     memory: 2Gi
 
 
 nominatim:
@@ -266,17 +266,17 @@ ingress:
   ##
   secrets: [ ]
 
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Enable resource limits. This is important for the initialization phase.