### PR TITLE
feat(loki-scalable): Make it possible to store secrets for Loki in AWS SM

### DIFF
--- a/charts/modules/apps/loki-scalable/Chart.yaml
+++ b/charts/modules/apps/loki-scalable/Chart.yaml
@@ -32,6 +32,7 @@ dependencies:
     version: "0.41.0"
     repository: "oci://ghcr.io/luminartech/helm-charts-public"
     condition: crossplane-aws-secretsmanager.enabled
-  - name: common-res
-    version: "1.0.18"
+  - name: external-secrets
+    version: "0.9.13-2"
     repository: "oci://ghcr.io/luminartech/helm-charts-public"
+    condition: external-secrets.enabled

--- a/charts/modules/apps/loki-scalable/Chart.yaml
+++ b/charts/modules/apps/loki-scalable/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "5.43.3"
 description: A wrapper Helm chart for loki scalable
 name: loki-scalable
-version: "5.43.3-1"
+version: "5.43.3-2"
 home: "https://github.com/luminartech/helm-charts-public"
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/loki-scalable
@@ -32,3 +32,6 @@ dependencies:
     version: "0.41.0"
     repository: "oci://ghcr.io/luminartech/helm-charts-public"
     condition: crossplane-aws-secretsmanager.enabled
+  - name: common-res
+    version: "1.0.18"
+    repository: "oci://ghcr.io/luminartech/helm-charts-public"

--- a/charts/modules/apps/loki-scalable/README.md
+++ b/charts/modules/apps/loki-scalable/README.md
@@ -29,8 +29,8 @@
 | `global.awsDeletionPolicy`      | Default crossplane deletion policy for all resources deployed by this helm chart..                          | `Orphan`                         |
 | `global.secretStoreRef`         | External Secrets secret store ref to fetch AWS secret for repo creds                                        | `cluster-secret-store-aws`       |
 
-
 ### loki
+
 
 
 

--- a/charts/modules/apps/loki-scalable/README.md
+++ b/charts/modules/apps/loki-scalable/README.md
@@ -46,6 +46,7 @@
 
 
 
+
 ## Configuration and installation details
 
 

--- a/charts/modules/apps/loki-scalable/values.yaml
+++ b/charts/modules/apps/loki-scalable/values.yaml
@@ -347,3 +347,32 @@ promtail:
     - name: machine-id
       mountPath: /etc/machine-id
       readOnly: true
+
+## @skip external-secrets
+external-secrets:
+  enabled: false
+  AWSExternalSecret:
+    enabled: true
+    items:
+      gateway-auth:
+        # name: 'grafana-secrets'
+        namespace: '{{ .Release.Namespace }}'
+        source:
+          secretStoreRef:
+            name: '{{ .Values.global.secretStoreRef }}'
+          data:
+            auth:
+              awsSecretName: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-gateway-auth'
+              awsSecretKey: 'auth'
+
+## @skip crossplane-aws-secretsmanager
+crossplane-aws-secretsmanager:
+  enabled: false
+  Secret:
+    items:
+      gateway-auth:
+        apiVersion: secretsmanager.aws.upbound.io/v1beta1
+        name: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-gateway-auth'
+        forProvider:
+          name: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-gateway-auth'
+          description: "Grafana secrets and tokens for {{ .Values.global.team }}-{{ .Values.global.environment }} Deployment"

--- a/charts/modules/apps/loki-scalable/values.yaml
+++ b/charts/modules/apps/loki-scalable/values.yaml
@@ -355,7 +355,6 @@ external-secrets:
     enabled: true
     items:
       gateway-auth:
-        # name: 'grafana-secrets'
         namespace: '{{ .Release.Namespace }}'
         source:
           secretStoreRef:

--- a/charts/modules/apps/monitoring/values.yaml
+++ b/charts/modules/apps/monitoring/values.yaml
@@ -180,6 +180,19 @@ external-secrets:
             admin-password:
               awsSecretName: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafanaadmin-creds'
               awsSecretKey: 'admin-password'
+      grafana-secrets:
+        # name: 'grafana-secrets'
+        namespace: '{{ .Release.Namespace }}'
+        source:
+          secretStoreRef:
+            name: '{{ .Values.global.secretStoreRef }}'
+          data:
+            LOKI_USERNAME:
+              awsSecretName: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafana-secrets'
+              awsSecretKey: 'LOKI_USERNAME'
+            LOKI_PASSWORD:
+              awsSecretName: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafana-secrets'
+              awsSecretKey: 'LOKI_PASSWORD'
 
 ## @skip crossplane-aws-secretsmanager
 crossplane-aws-secretsmanager:
@@ -192,3 +205,9 @@ crossplane-aws-secretsmanager:
         forProvider:
           name: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafanaadmin-creds'
           description: "Grafana Admin creds for {{ .Values.global.team }}-{{ .Values.global.environment }} Deployment"
+      grafana-secrets:
+        apiVersion: secretsmanager.aws.upbound.io/v1beta1
+        name: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafana-secrets'
+        forProvider:
+          name: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafana-secrets'
+          description: "Grafana secrets and tokens for {{ .Values.global.team }}-{{ .Values.global.environment }} Deployment"

--- a/charts/modules/apps/monitoring/values.yaml
+++ b/charts/modules/apps/monitoring/values.yaml
@@ -180,19 +180,6 @@ external-secrets:
             admin-password:
               awsSecretName: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafanaadmin-creds'
               awsSecretKey: 'admin-password'
-      grafana-secrets:
-        # name: 'grafana-secrets'
-        namespace: '{{ .Release.Namespace }}'
-        source:
-          secretStoreRef:
-            name: '{{ .Values.global.secretStoreRef }}'
-          data:
-            LOKI_USERNAME:
-              awsSecretName: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafana-secrets'
-              awsSecretKey: 'LOKI_USERNAME'
-            LOKI_PASSWORD:
-              awsSecretName: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafana-secrets'
-              awsSecretKey: 'LOKI_PASSWORD'
 
 ## @skip crossplane-aws-secretsmanager
 crossplane-aws-secretsmanager:
@@ -205,9 +192,3 @@ crossplane-aws-secretsmanager:
         forProvider:
           name: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafanaadmin-creds'
           description: "Grafana Admin creds for {{ .Values.global.team }}-{{ .Values.global.environment }} Deployment"
-      grafana-secrets:
-        apiVersion: secretsmanager.aws.upbound.io/v1beta1
-        name: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafana-secrets'
-        forProvider:
-          name: '{{ .Values.global.team }}-{{ .Values.global.environment }}-{{ .Values.global.deploymentName }}-grafana-secrets'
-          description: "Grafana secrets and tokens for {{ .Values.global.team }}-{{ .Values.global.environment }} Deployment"


### PR DESCRIPTION
The goal is to add ingress to Loki's gateway with basic auth. Latter requires a secret.