### PR TITLE
gitops/upgrade-argocd-rollout-1

### DIFF
--- a/charts/modules/apps/argo-cd/Chart.yaml
+++ b/charts/modules/apps/argo-cd/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "2.9.3"
 description: A Wrapper Helm chart for argo-cd
 name: argo-cd
-version: "5.52.2-1"
+version: "5.53.1"
 home: "https://github.com/luminartech/helm-charts-public"
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/argo-cd
@@ -13,7 +13,7 @@ maintainers:
     email: ipe@luminartech.com
 dependencies:
   - name: argo-cd
-    version: "5.52.2"
+    version: "5.53.1"
     repository: https://argoproj.github.io/argo-helm
     condition: argo-cd.enabled
   - name: common-gitops


### PR DESCRIPTION
- Upgrade argocd app from 2.9.3 to 2.9.4
- Refer chart changes https://artifacthub.io/packages/helm/argo/argo-cd/5.53.1?modal=values&compare-to=5.52.2
- Refer ChangeLog https://artifacthub.io/packages/helm/argo/argo-cd/5.52.2?modal=changelog&version=5.53.1
