### PR TITLE
gitops/upgrade-argocd-rollout-3

### DIFF
--- a/charts/modules/apps/argo-cd/Chart.yaml
+++ b/charts/modules/apps/argo-cd/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "2.9.3"
 description: A Wrapper Helm chart for argo-cd
 name: argo-cd
-version: "5.55.0"
+version: "6.1.0"
 home: "https://github.com/luminartech/helm-charts-public"
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/argo-cd
@@ -13,7 +13,7 @@ maintainers:
     email: ipe@luminartech.com
 dependencies:
   - name: argo-cd
-    version: "5.55.0"
+    version: "6.1.0"
     repository: https://argoproj.github.io/argo-helm
     condition: argo-cd.enabled
   - name: common-gitops


### PR DESCRIPTION
- Upgrade to App version 2.10.1 (chart version 6.1.0) to address below issue

`ComparisonError: Failed to load live state: failed to get cluster info for "https://kubernetes.default.svc": error getting cluster: controller is configured to ignore cluster https://kubernetes.default.svc;ComparisonError`