### PR TITLE
gitops/upgrade-karpenter-1.0.9

### DIFF
--- a/charts/modules/apps/karpenter/Chart.yaml
+++ b/charts/modules/apps/karpenter/Chart.yaml
@@ -1,10 +1,10 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: "0.37.7"
+appVersion: "1.0.9"
 description: A Helm chart for karpenter + related resources
 name: karpenter
-version: "0.37.7"
+version: "1.0.9"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/karpenter
@@ -28,12 +28,12 @@ dependencies:
     repository: "oci://ghcr.io/luminartech/helm-charts-public"
     condition: crossplane-aws-cloudwatch.enabled
   - name: karpenter
-    version: "0.37.7"
+    version: "1.0.9"
     repository: "oci://public.ecr.aws/karpenter"
     condition: karpenter.enabled
     # Karpenter helm chart only creates CRDs during the first install.
     # There's a separate helm chart for managing them afterwards.
   - name: karpenter-crd
-    version: "0.37.7"
+    version: "1.0.9"
     repository: "oci://public.ecr.aws/karpenter"
     condition: karpenter-crd.enabled

--- a/charts/modules/apps/karpenter/values.yaml
+++ b/charts/modules/apps/karpenter/values.yaml
@@ -407,7 +407,7 @@ karpenter:
         cpu: 0.25
         memory: 512Mi
       limits:
-        cpu: 0.5
+        cpu: 1
         memory: 1Gi
 
 ## @skip NodePool


### PR DESCRIPTION
- [As per v1 Migration](https://karpenter.sh/v1.0/upgrading/v1-migration/#upgrade-procedure)
  - Make sure webhook is enabled (Step 4 & 5) in the top layer
  - Upgrading to version 1.0.9 as mentioned in the Migration document and [also Compatibility chart](https://karpenter.sh/v1.1/upgrading/compatibility/#compatibility-matrix)
  - Setting CPU limit to the value mentioned in v1 Migration document.
  - [Ubuntu AMIFamily Removed](https://karpenter.sh/v1.0/upgrading/v1-migration/#ubuntu-amifamily-removed)
  - Will fix any IAM policy changes in followup PR, if permission related failures are observed.