### PR TITLE
gitops/upgrade-karpenter-1.0.9

### DIFF
--- a/charts/modules/apps/karpenter/Chart.yaml
+++ b/charts/modules/apps/karpenter/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "1.0.9"
 description: A Helm chart for karpenter + related resources
 name: karpenter
-version: "1.0.9-2"
+version: "1.0.9-3"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/karpenter

--- a/charts/modules/apps/karpenter/templates/ec2-node-class.yaml
+++ b/charts/modules/apps/karpenter/templates/ec2-node-class.yaml
@@ -4,7 +4,7 @@
 {{- range $name, $item := $kindObj.items -}}
   {{- if eq (include "common-gitops.utils.itemEnabled" (dict "root" $root "name" $name "kind" $kind)) "true" }}
 ---
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: {{ $kind }}
 metadata:
   name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" .name) }}

--- a/charts/modules/apps/karpenter/templates/node-pool.yaml
+++ b/charts/modules/apps/karpenter/templates/node-pool.yaml
@@ -4,7 +4,7 @@
 {{- range $name, $item := $kindObj.items -}}
   {{- if eq (include "common-gitops.utils.itemEnabled" (dict "root" $root "name" $name "kind" $kind)) "true" }}
 ---
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: {{ $kind }}
 metadata:
   name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" .name) }}


### PR DESCRIPTION
- Migrate to v1 from v1beta1. Required for the upgrade to 1.1x