### PR TITLE
Enable v1 api

### DIFF
--- a/charts/modules/apps/karpenter/templates/ec2-node-class.yaml
+++ b/charts/modules/apps/karpenter/templates/ec2-node-class.yaml
@@ -4,7 +4,7 @@
 {{- range $name, $item := $kindObj.items -}}
   {{- if eq (include "common-gitops.utils.itemEnabled" (dict "root" $root "name" $name "kind" $kind)) "true" }}
 ---
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: {{ $kind }}
 metadata:
   name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" .name) }}

--- a/charts/modules/apps/karpenter/templates/node-pool.yaml
+++ b/charts/modules/apps/karpenter/templates/node-pool.yaml
@@ -4,7 +4,7 @@
 {{- range $name, $item := $kindObj.items -}}
   {{- if eq (include "common-gitops.utils.itemEnabled" (dict "root" $root "name" $name "kind" $kind)) "true" }}
 ---
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: {{ $kind }}
 metadata:
   name: {{ include "common-gitops.names.itemFullname" (dict "root" $root "name" $name "override" .name) }}


### PR DESCRIPTION
- Refer: https://karpenter.sh/v1.0/upgrading/v1-migration/#ubuntu-amifamily-removed

`If you are upgrading to v1.0.x and already have v1beta1 Ubuntu EC2NodeClasses, all you need to do is specify amiSelectorTerms and Karpenter will translate your EC2NodeClasses to the v1 equivalent (as shown below). Failure to specify amiSelectorTerms will result in the EC2NodeClass and all referencing NodePools to become NotReady. These NodePools and EC2NodeClasses would then be ignored for provisioning and drift.`

- If you see out-of-sync state, delete the EC2NodeClass manually by removing finalizer and let ArgoCD recreate it