### PR TITLE
gitops: Upgrade Karpenter from v1.0.x to v1.1.x

### DIFF
--- a/charts/modules/apps/karpenter/Chart.yaml
+++ b/charts/modules/apps/karpenter/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "1.0.9"
 description: A Helm chart for karpenter + related resources
 name: karpenter
-version: "1.0.9-5"
+version: "1.1.4"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/karpenter
@@ -28,12 +28,12 @@ dependencies:
     repository: "oci://ghcr.io/luminartech/helm-charts-public"
     condition: crossplane-aws-cloudwatch.enabled
   - name: karpenter
-    version: "1.0.9"
+    version: "1.1.4"
     repository: "oci://public.ecr.aws/karpenter"
     condition: karpenter.enabled
     # Karpenter helm chart only creates CRDs during the first install.
     # There's a separate helm chart for managing them afterwards.
   - name: karpenter-crd
-    version: "1.0.9"
+    version: "1.1.4"
     repository: "oci://public.ecr.aws/karpenter"
     condition: karpenter-crd.enabled


### PR DESCRIPTION
- Ugrade to version 1.1.4 [Refer Tags here](https://gallery.ecr.aws/karpenter/karpenter)
- Version 1.1.x removed support for v1beta1. Ensure the API was migrated to v1 before applying this upgrade.