### PR TITLE
SW-23366: Switch ArgoCD to consistent-hashing algorithm

### DIFF
--- a/charts/modules/apps/argo-cd/Chart.yaml
+++ b/charts/modules/apps/argo-cd/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "2.14.2"
 description: A Wrapper Helm chart for argo-cd
 name: argo-cd
-version: "7.8.2-1"
+version: "7.8.12-1"
 home: "https://github.com/luminartech/helm-charts-public"
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/argo-cd
@@ -13,7 +13,7 @@ maintainers:
     email: ipe@luminartech.com
 dependencies:
   - name: argo-cd
-    version: "7.8.2"
+    version: "7.8.12"
     repository: https://argoproj.github.io/argo-helm
     condition: argo-cd.enabled
   - name: common-gitops

--- a/charts/modules/apps/argo-cd/README.md
+++ b/charts/modules/apps/argo-cd/README.md
@@ -76,6 +76,7 @@ sequenceDiagram
 
 
 
+
 ## Configuration and installation details
 
 

--- a/charts/modules/apps/argo-cd/values.yaml
+++ b/charts/modules/apps/argo-cd/values.yaml
@@ -438,8 +438,8 @@ argo-cd:
       url: "https://argo-cd.dev.domain.com"
       server.rbac.log.enforce.enable: true
     params:
-      # -- Set Sharding Algorithm to round-robin
-      controller.sharding.algorithm: round-robin
+      # -- Set Sharding Algorithm to consistent-hashing
+      controller.sharding.algorithm: consistent-hashing
     # TODO: All of these repositories needs to be reviewed and moved as secrets
     repositories:
       helm-helm-repo:


### PR DESCRIPTION
- switch from round-robin to consistent-hashing algorithm for shard distribution
- upgrade ArgoCD from v7.8.2 to v7.8.12