### PR TITLE
Update httpPutResponseHopLimit to 2

### DIFF
--- a/charts/modules/apps/karpenter/Chart.yaml
+++ b/charts/modules/apps/karpenter/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "1.3.2"
 description: A Helm chart for karpenter + related resources
 name: karpenter
-version: "1.3.2"
+version: "1.3.2-1"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/karpenter

--- a/charts/modules/apps/karpenter/values.yaml
+++ b/charts/modules/apps/karpenter/values.yaml
@@ -452,6 +452,11 @@ EC2NodeClass:
             deleteOnTermination: true
             throughput: 500
             # snapshotID: snap-0123456789
+      metadataOptions:
+        httpEndpoint: enabled
+        httpProtocolIPv6: disabled
+        httpPutResponseHopLimit: 2
+        httpTokens: required
       role: '{{ .Values.global.eksClusterName }}-karpenter-node'
       securityGroupSelectorTerms:
         - name: "eks-cluster-sg-{{ .Values.global.eksClusterName }}-*"


### PR DESCRIPTION
## What issue does this address:

- EBS CSI controller pod fails to acces AWS Instance Metadata Service (IMDS) and returns below error

`Could not attach volume "vol-xxxxx" to node "i-xxxxx": error listing AWS instances: operation error EC2: DescribeInstances, get identity: get credentials: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, canceled, context deadline exceeded`

## What is the root cause of this issue
- Karpenter v1.0 onwards, the default value was changed to "1" https://karpenter.sh/v1.0/concepts/nodeclasses/#specmetadataoptions

- In previous version, it was "2"
https://karpenter.sh/v0.32/concepts/nodeclasses/#specmetadataoptions

- **`httpPutResponseHopLimit`** is a setting in AWS Instance Metadata Service (IMDS) that controls the number of network hops allowed for instance metadata PUT response packets.
- **`Value: 1`** restricts responses to the EC2 instance Itself
- Incase of EKS, where the workloads run inside a container, this value should be set to 2.