### PR TITLE
SW-23600: bump NGINX Helm chart to v4.12.1

### DIFF
--- a/charts/modules/apps/ingress-nginx/Chart.yaml
+++ b/charts/modules/apps/ingress-nginx/Chart.yaml
@@ -1,10 +1,10 @@
 annotations:
   category: Application
 apiVersion: v2
-appVersion: "4.9.1"
+appVersion: "4.12.1"
 description: A Helm chart for ingress-nginx
 name: ingress-nginx
-version: "4.9.1-1"
+version: "4.12.1-1"
 home: "https://github.com/luminartech/helm-charts-public"
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/ingress-nginx
@@ -14,5 +14,5 @@ maintainers:
 dependencies:
   - name: ingress-nginx
     repository: https://kubernetes.github.io/ingress-nginx
-    version: "4.9.1"
+    version: "4.12.1"
     condition: ingress-nginx.enabled

--- a/charts/modules/apps/ingress-nginx/Chart.yaml
+++ b/charts/modules/apps/ingress-nginx/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "4.12.1"
 description: A Helm chart for ingress-nginx
 name: ingress-nginx
-version: "4.12.1-1"
+version: "4.12.1"
 home: "https://github.com/luminartech/helm-charts-public"
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/ingress-nginx


### PR DESCRIPTION
- in order to address:
> “Today, the ingress-nginx maintainers have [released patches for a batch of critical vulnerabilities](https://github.com/kubernetes/ingress-nginx/releases) that could make it easy for attackers to take over your Kubernetes cluster. If you are among the over 40% of Kubernetes administrators using [ingress-nginx](https://github.com/kubernetes/ingress-nginx/), you should take action immediately to protect your users and data.”