### PR TITLE
fix/karpenter-nodepool-spec

### DIFF
--- a/charts/modules/apps/karpenter/Chart.yaml
+++ b/charts/modules/apps/karpenter/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: "1.5.0"
 description: A Helm chart for karpenter + related resources
 name: karpenter
-version: "1.5.0"
+version: "1.5.0-0"
 home: https://helm-repo-public.luminarinfra.com/
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/karpenter

--- a/charts/modules/apps/karpenter/values.yaml
+++ b/charts/modules/apps/karpenter/values.yaml
@@ -415,6 +415,8 @@ NodePool:
           # required field
           nodeClassRef:
             name: '{{ include "common-gitops.names.release" . }}'
+            group: karpenter.k8s.aws
+            kind: EC2NodeClass
           # required field
           requirements:
             - key: "karpenter.sh/capacity-type"


### PR DESCRIPTION
Fix below error:

`Failed sync attempt to 1.5.0: one or more objects failed to apply, reason: NodePool.karpenter.sh  [spec.disruption.consolidateAfter: Required value, spec.template.spec.nodeClassRef.group: Required value, spec.template.spec.nodeClassRef.kind: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]`