### PR TITLE
chore: upgrade Kube Prometheus Stack Helm chart to v69.4.1

### DIFF
--- a/charts/modules/apps/monitoring/Chart.yaml
+++ b/charts/modules/apps/monitoring/Chart.yaml
@@ -1,10 +1,10 @@
 annotations:
   category: Application
 apiVersion: v2
-appVersion: "0.72.0"
+appVersion: "0.80.0"
 description: A Helm chart for monitoring
 name: monitoring
-version: "57.2.1-1"
+version: "69.4.1"
 home: "https://github.com/luminartech/helm-charts-public"
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/apps/monitoring
@@ -13,7 +13,7 @@ maintainers:
     email: ipe@luminartech.com
 dependencies:
   - name: kube-prometheus-stack
-    version: "57.2.1"
+    version: "69.4.1"
     repository: https://prometheus-community.github.io/helm-charts
   - name: crossplane-aws-secretsmanager
     version: "0.41.0"


### PR DESCRIPTION
- upgrade Kube Prometheus Stack Helm chart from current `v57.2.1` to `v69.4.1`
- upgrade Prometheus Alertmanager from `v0.27.0` to `v0.28.0`
- upgrade Prometheus from `v2.51.0` to `v3.1.0`
- upgrade Grafana from `v10.3.1` to `v11.5.1`
- upgrade Kube state metrics from `v5.18` to `v5.29`
- https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/69.4.1?modal=values&compare-to=57.2.1
- https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-69.4.1
- https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-69.4.1/charts/kube-prometheus-stack/values.yaml