### PR TITLE
SW-29763: Upgrade AMI type from AL2_x86_64 to AL2023_x86_64_STANDARD

### DIFF
--- a/charts/modules/apps/karpenter/values.yaml
+++ b/charts/modules/apps/karpenter/values.yaml
@@ -427,7 +427,7 @@ NodePool:
               values: ["amd64"]
             - key: kubernetes.io/os
               operator: In
-              values:	["linux"]
+              values: ["linux"]
           # taints:
           #   - key: "class"
           #     value: "set me"

--- a/charts/modules/infra/aws-eks/Chart.yaml
+++ b/charts/modules/infra/aws-eks/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 appVersion: "0.41.0"
 description: A Helm chart for IAC resources needed by EKS
 name: aws-eks
-version: "0.41.0-12"
+version: "0.41.0-13"
 home: "https://github.com/luminartech/helm-charts-public"
 sources:
   - https://github.com/luminartech/helm-charts-public/tree/main/charts/modules/infra/aws-eks

--- a/charts/modules/infra/aws-eks/values.yaml
+++ b/charts/modules/infra/aws-eks/values.yaml
@@ -528,7 +528,7 @@ crossplane-aws-eks:
     items:
       private:
         forProvider:
-          amiType: AL2_x86_64
+          amiType: AL2023_x86_64_STANDARD
           capacityType: SPOT
           clusterNameRef:
             name: '{{ include "common-gitops.names.release" . }}'
@@ -559,7 +559,7 @@ crossplane-aws-eks:
             name: '{{ include "common-gitops.names.release" . }}'
       public:
         forProvider:
-          amiType: AL2_x86_64
+          amiType: AL2023_x86_64_STANDARD
           capacityType: SPOT
           clusterNameRef:
             name: '{{ include "common-gitops.names.release" . }}'


### PR DESCRIPTION
EKS 1.33 compatibility issue:

Checks if any nodes in the cluster are running Amazon Linux 2. Support for Amazon Linux 2 on Amazon EKS will end on November 26, 2025. Additionally, Amazon EKS will not release Amazon Linux 2 AMIs for Kubernetes version 1.33 and higher │ Migrate all EKS nodes using Amazon Linux 2 AMIs to Bottlerocket or Amazon Linux 2023 AMIs before November 26, 2025, or prior to upgrading to EKS version 1.33.